### PR TITLE
move browserslist to package.json, use more modern default browsers

### DIFF
--- a/src/Resources/skeletons/BaseExtension/fluid_styled_content/Build/.browserslistrc
+++ b/src/Resources/skeletons/BaseExtension/fluid_styled_content/Build/.browserslistrc
@@ -1,0 +1,3 @@
+"browserslist": [
+        "defaults"
+]

--- a/src/Resources/skeletons/BaseExtension/fluid_styled_content/Build/Gruntfile.js.twig
+++ b/src/Resources/skeletons/BaseExtension/fluid_styled_content/Build/Gruntfile.js.twig
@@ -1,4 +1,4 @@
-const sass = require('node-sass');
+const sass = require('sass');
 
 module.exports = function(grunt) {
 

--- a/src/Resources/skeletons/BaseExtension/fluid_styled_content/Build/Gruntfile.js.twig
+++ b/src/Resources/skeletons/BaseExtension/fluid_styled_content/Build/Gruntfile.js.twig
@@ -53,13 +53,7 @@ module.exports = function(grunt) {
             options: {
                 map: false,
                 processors: [
-                    require('autoprefixer')({
-                        browsers: [
-                            'Last 2 versions',
-                            'Firefox ESR',
-                            'IE 9'
-                        ]
-                    })
+                    require('autoprefixer')()
                 ]
             },
             layout: {

--- a/src/Resources/skeletons/BaseExtension/fluid_styled_content/Build/package.json.twig
+++ b/src/Resources/skeletons/BaseExtension/fluid_styled_content/Build/package.json.twig
@@ -18,14 +18,11 @@
     "grunt-postcss": "^0.9.0",
     "grunt-sass": "^3.0.2",
     "autoprefixer": "^9.5.0",
-    "node-sass": "^4.11.0"
+    "sass": "^1.32.2"
   },
   "scripts": {
     "build": "./node_modules/.bin/grunt",
     "css": "./node_modules/.bin/grunt css",
     "watch": "./node_modules/.bin/grunt watch"
-  },
-  "browserslist": [
-    "defaults"
-  ],
+  }
 }

--- a/src/Resources/skeletons/BaseExtension/fluid_styled_content/Build/package.json.twig
+++ b/src/Resources/skeletons/BaseExtension/fluid_styled_content/Build/package.json.twig
@@ -24,7 +24,7 @@
     "build": "./node_modules/.bin/grunt",
     "css": "./node_modules/.bin/grunt css",
     "watch": "./node_modules/.bin/grunt watch"
-  }
+  },
   "browserslist": [
     "defaults"
   ],

--- a/src/Resources/skeletons/BaseExtension/fluid_styled_content/Build/package.json.twig
+++ b/src/Resources/skeletons/BaseExtension/fluid_styled_content/Build/package.json.twig
@@ -25,4 +25,7 @@
     "css": "./node_modules/.bin/grunt css",
     "watch": "./node_modules/.bin/grunt watch"
   }
+  "browserslist": [
+    "defaults"
+  ],
 }


### PR DESCRIPTION
```
  Replace Autoprefixer browsers option to Browserslist config.
  Use browserslist key in package.json or .browserslistrc file.

  Using browsers option can cause errors. Browserslist config
  can be used for Babel, Autoprefixer, postcss-normalize and other tools.
```