### PR TITLE
Fix RTE configuration option for styles (v12/v13)

### DIFF
--- a/resources/packages/fluid_styled_content/12.4/src/Configuration/RTE/Default.yaml.twig
+++ b/resources/packages/fluid_styled_content/12.4/src/Configuration/RTE/Default.yaml.twig
@@ -7,8 +7,9 @@ editor:
     config:
         contentsCss: "EXT:{{ package.extensionKey }}/Resources/Public/Css/rte.css"
 
-        stylesSet:
-            - { name: "Lead", element: "p", attributes: { 'class': 'lead' } }
+        style:
+            definitions:
+                - { name: "Lead", element: "p", attributes: { 'class': 'lead' } }
 
         toolbarGroups:
             - { name: styles, groups: [ format, styles ] }

--- a/resources/packages/fluid_styled_content/12.4/src/Configuration/RTE/Default.yaml.twig
+++ b/resources/packages/fluid_styled_content/12.4/src/Configuration/RTE/Default.yaml.twig
@@ -9,7 +9,7 @@ editor:
 
         style:
             definitions:
-                - { name: "Lead", element: "p", attributes: { 'class': 'lead' } }
+                - { name: "Lead", element: "p", classes: ['lead'] }
 
         toolbarGroups:
             - { name: styles, groups: [ format, styles ] }

--- a/resources/packages/fluid_styled_content/13.4/src/Configuration/RTE/Default.yaml.twig
+++ b/resources/packages/fluid_styled_content/13.4/src/Configuration/RTE/Default.yaml.twig
@@ -7,8 +7,9 @@ editor:
     config:
         contentsCss: "EXT:{{ package.extensionKey }}/Resources/Public/Css/rte.css"
 
-        stylesSet:
-            - { name: "Lead", element: "p", attributes: { 'class': 'lead' } }
+        style:
+            definitions:
+                - { name: "Lead", element: "p", attributes: { 'class': 'lead' } }
 
         toolbarGroups:
             - { name: styles, groups: [ format, styles ] }

--- a/resources/packages/fluid_styled_content/13.4/src/Configuration/RTE/Default.yaml.twig
+++ b/resources/packages/fluid_styled_content/13.4/src/Configuration/RTE/Default.yaml.twig
@@ -9,7 +9,7 @@ editor:
 
         style:
             definitions:
-                - { name: "Lead", element: "p", attributes: { 'class': 'lead' } }
+                - { name: "Lead", element: "p", classes: ['lead'] }
 
         toolbarGroups:
             - { name: styles, groups: [ format, styles ] }


### PR DESCRIPTION
This PR changes the styles configuration to use the new identifiers (styles.definitions and inside of it classes instead of attributes.class)